### PR TITLE
Fixed spelling mistake: from MoonSharpHide to MoonSharpHideMember

### DIFF
--- a/objects.md
+++ b/objects.md
@@ -704,7 +704,7 @@ descr.RemoveMember("SomeMember");
 Otherwise, simply add this attribute to the type declaration:
 
 {% highlight csharp %}
-[MoonSharpHide("SomeMember")]
+[MoonSharpHideMember("SomeMember")]
 public class SomeType
 ...
 {% endhighlight %}


### PR DESCRIPTION
MoonSharp.Interpreter.MoonSharpHide doesnt actually exist

its MoonSharpHideMember